### PR TITLE
ActiveRecord Connections & RailsAdmin Integrations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    ffi (1.15.4)
+    ffi (1.15.4-x64-mingw32)
     globalid (0.5.2)
       activesupport (>= 5.0)
     haml (5.2.2)
@@ -161,7 +161,6 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
@@ -169,10 +168,7 @@ GEM
     multipart-post (2.1.1)
     nested_form (0.3.2)
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.12.5-x64-mingw32)
       racc (~> 1.4)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -289,7 +285,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    ruby2_keywords (0.0.5)
     rubocop (1.22.2)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -302,10 +297,11 @@ GEM
     rubocop-ast (1.12.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
+    sassc (2.4.0-x64-mingw32)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -340,9 +336,12 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2021.5)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    wdm (0.1.1)
     web-console (4.1.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -366,6 +365,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
   x86_64-linux
 
 DEPENDENCIES
@@ -396,6 +396,7 @@ DEPENDENCIES
   spring
   turbolinks (~> 5)
   tzinfo-data
+  wdm (>= 0.1.0)
   web-console (>= 4.1.0)
   webdrivers
   webpacker (~> 5.0)

--- a/app/controllers/events_users_controller.rb
+++ b/app/controllers/events_users_controller.rb
@@ -42,7 +42,7 @@ class EventsUsersController < ApplicationController
     user = if event_user.key?(:user_id)
              User.find(event_user[:user_id])
            else
-             User.find_or_initialize_by(email: event_user.require(:email))
+             User.find_or_initialize_by(email: event_user.require(:email).downcase)
            end
 
     # Update name in case it is outdated

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,4 +4,8 @@ class Contact < ApplicationRecord
   validates :firstname, presence: true
   validates :lastname, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  def name
+    "#{firstname} #{lastname}"
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,11 +1,31 @@
 # frozen_string_literal: true
 
 class Contact < ApplicationRecord
+  attribute :affiliation, :string
   validates :firstname, presence: true
   validates :lastname, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   def name
     "#{firstname} #{lastname}"
+  end
+
+  rails_admin do
+    configure :firstname do
+      label 'First name'
+    end
+
+    configure :lastname do
+      label 'Last name'
+    end
+
+    list do
+      configure :name do
+        formatted_value { bindings[:object].name }
+        read_only true
+        help ''
+      end
+      fields :id, :email, :name, :affiliation, :title
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,7 @@ class Event < ApplicationRecord
   validates :eventCode, presence: true
   validates :endTime, date: { after: :startTime, allow_blank: true }
 
-  has_many :events_users, class_name: "EventsUsers", inverse_of: :event, dependent: :destroy
+  has_many :events_users, class_name: 'EventsUsers', inverse_of: :event, dependent: :destroy
   has_many :users, through: :events_users, inverse_of: :events
 
   attribute :eventCode, :string, default: -> { generate_code }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,12 +4,26 @@ require 'date'
 require 'date_validator'
 
 class Event < ApplicationRecord
+  attribute :name, :string
+  attribute :eventCode, :string
+  attribute :description, :string
+  attribute :date, :date
+  attribute :startTime, :time
+  attribute :endTime, :time
+
   validates :name, presence: true
   validates :date, presence: true
   validates :eventCode, presence: true
-  validates :endTime, date: { after: proc { :startTime }, allow_blank: true }
+  validates :endTime, date: { after: :startTime, allow_blank: true }
+
+  has_many :events_users, class_name: "EventsUsers", inverse_of: :event, dependent: :destroy
+  has_many :users, through: :events_users, inverse_of: :events
 
   attribute :eventCode, :string, default: -> { generate_code }
+
+  # def point_value
+  #   1
+  # end
 
   def self.naive_now
     # Conversion to a naive time since the database stores local times for events without timezone info

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -90,4 +90,41 @@ class Event < ApplicationRecord
     code = length.times.map { valid_characters.sample }.join until code && !Event.exists?(eventCode: code)
     code
   end
+
+  def attendance
+    users.size
+  end
+
+  rails_admin do
+    configure :startTime do
+      label 'Start time'
+    end
+
+    configure :endTime do
+      label 'End time'
+    end
+
+    configure :eventCode do
+      label 'Event code'
+    end
+
+    configure :events_users do
+      label 'Check-ins'
+      hide
+    end
+
+    configure :users do
+      label 'Attendees'
+    end
+
+    configure :attendance do
+      formatted_value { bindings[:object].attendance }
+      read_only true
+      help ''
+    end
+
+    list do
+      fields :id, :name, :eventCode, :date, :startTime, :attendance
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,14 +21,33 @@ class Event < ApplicationRecord
 
   attribute :eventCode, :string, default: -> { generate_code }
 
-  # def point_value
-  #   1
-  # end
+  def self.naive_time(time)
+    # Conversion to a "naive" time since the database stores local times for events without timezone info
+    # RailsAdmin breaks if you try to use real Ruby/Rails timezone support
+    # Rationale:
+    # This lets users continue to enter in their local times, which are stored in the database with no known offset
+    # So this method removes the offset from Ruby's time classes to become comparable with records in the database
+    # See Event::ongoing, Event::upcoming, and Event::past for examples
+    # NOTE: this is only relevant for the :date, :startTime, and :endTime attributes of Event
+    time.in_time_zone('Central Time (US & Canada)').change(offset: 0)
+  end
+
+  def self.corrected_time(time)
+    # Restores the timezone from a "naive" time stored in the database by imbuing the correct offset
+    # This is the inverse operation of Event::naive_time, located above
+    # Use this in e.g. `if Event.corrected_time(event.startTime) > Time.now`
+    # or generally when doing time calculations in Ruby, as opposed to directly in the database
+
+    # Reflects the UTC offset for the particular date associated with `time`, respecting daylight savings time
+    # Normally -6 or -5 for CST and CDT respectively, so `time + 5.hour` approximates an accurate timestamp
+    # to roughly ensure the correct day is being considered when retrieving the actual offset
+    true_offset = (time + 5.hour).in_time_zone('Central Time (US & Canada)').utc_offset / 1.hour
+    # After changing the offset, the in_time_zone call mainly just provides the remaining timezone locale info for Ruby
+    time.change(offset: true_offset).in_time_zone('Central Time (US & Canada)')
+  end
 
   def self.naive_now
-    # Conversion to a naive time since the database stores local times for events without timezone info
-    # RailsAdmin breaks if you try to use real Ruby/Rails timezone support
-    Time.now.in_time_zone('Central Time (US & Canada)').change(offset: 0)
+    naive_time(Time.now)
   end
 
   def self.ongoing

--- a/app/models/events_users.rb
+++ b/app/models/events_users.rb
@@ -19,4 +19,12 @@ class EventsUsers < ApplicationRecord
                        format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ }
   validates :user_id, presence: true,
                       format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ }
+
+  rails_admin do
+    label 'Check-ins'
+
+    list do
+      fields :id, :event, :user
+    end
+  end
 end

--- a/app/models/events_users.rb
+++ b/app/models/events_users.rb
@@ -11,6 +11,7 @@ class EventsUsers < ApplicationRecord
   belongs_to :user, inverse_of: :events_users
 
   def name
+    # Expected by RailsAdmin for its views
     "#{user.name} @ #{event.name}"
   end
 

--- a/app/models/events_users.rb
+++ b/app/models/events_users.rb
@@ -4,6 +4,16 @@ class EventsUsers < ApplicationRecord
   attribute :event_id
   attribute :user_id
 
+  validates :event_id, presence: true
+  validates :user_id, presence: true
+
+  belongs_to :event, inverse_of: :events_users
+  belongs_to :user, inverse_of: :events_users
+
+  def name
+    "#{user.name} @ #{event.name}"
+  end
+
   validates :event_id, presence: true,
                        format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ }
   validates :user_id, presence: true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,4 +34,33 @@ class User < ApplicationRecord
     # Expected by RailsAdmin for its views
     "#{first_name} #{last_name}"
   end
+
+  def count_attended
+    events.size
+  end
+
+  rails_admin do
+    configure :isAdmin do
+      label 'Admin'
+    end
+
+    configure :events_users do
+      label 'Check-ins'
+      hide
+    end
+
+    configure :events do
+      label 'Attended'
+    end
+
+    configure :count_attended do
+      formatted_value { bindings[:object].count_attended }
+      read_only true
+      help ''
+    end
+
+    list do
+      fields :id, :email, :first_name, :last_name, :count_attended
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,14 @@ class User < ApplicationRecord
   validates :isAdmin, inclusion: { in: [true, false] }
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
+  has_many :events_users, class_name: "EventsUsers", inverse_of: :user, dependent: :destroy
+  has_many :events, through: :events_users, inverse_of: :users
+
   devise :omniauthable, omniauth_providers: [:google_oauth2]
+
+  # def total_points
+  #   events.sum { |e| e.point_value }
+  # end
 
   def self.from_google(options)
     # return nil unless options[:email] =~ /@tamu.edu\z/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   validates :isAdmin, inclusion: { in: [true, false] }
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
-  has_many :events_users, class_name: "EventsUsers", inverse_of: :user, dependent: :destroy
+  has_many :events_users, class_name: 'EventsUsers', inverse_of: :user, dependent: :destroy
   has_many :events, through: :events_users, inverse_of: :users
 
   devise :omniauthable, omniauth_providers: [:google_oauth2]

--- a/db/migrate/20211104161253_add_foreign_key_between_users_events_link_and_users.rb
+++ b/db/migrate/20211104161253_add_foreign_key_between_users_events_link_and_users.rb
@@ -1,0 +1,9 @@
+class AddForeignKeyBetweenUsersEventsLinkAndUsers < ActiveRecord::Migration[6.1]
+  def up
+    add_foreign_key :events_users, :users, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :events_users, column: :user_id
+  end
+end

--- a/db/migrate/20211104161253_add_foreign_key_between_users_events_link_and_users.rb
+++ b/db/migrate/20211104161253_add_foreign_key_between_users_events_link_and_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddForeignKeyBetweenUsersEventsLinkAndUsers < ActiveRecord::Migration[6.1]
   def up
     add_foreign_key :events_users, :users, on_delete: :cascade

--- a/db/migrate/20211104162538_add_foreign_key_between_users_events_link_and_events.rb
+++ b/db/migrate/20211104162538_add_foreign_key_between_users_events_link_and_events.rb
@@ -1,0 +1,9 @@
+class AddForeignKeyBetweenUsersEventsLinkAndEvents < ActiveRecord::Migration[6.1]
+  def up
+    add_foreign_key :events_users, :events, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :events_users, column: :event_id
+  end
+end

--- a/db/migrate/20211104162538_add_foreign_key_between_users_events_link_and_events.rb
+++ b/db/migrate/20211104162538_add_foreign_key_between_users_events_link_and_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddForeignKeyBetweenUsersEventsLinkAndEvents < ActiveRecord::Migration[6.1]
   def up
     add_foreign_key :events_users, :events, on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_021240) do
+ActiveRecord::Schema.define(version: 2021_11_04_162538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -47,7 +47,6 @@ ActiveRecord::Schema.define(version: 2021_10_26_021240) do
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "uid"
     t.string "email"
     t.boolean "isAdmin"
     t.datetime "created_at", precision: 6, null: false
@@ -56,4 +55,6 @@ ActiveRecord::Schema.define(version: 2021_10_26_021240) do
     t.string "last_name"
   end
 
+  add_foreign_key "events_users", "events", on_delete: :cascade
+  add_foreign_key "events_users", "users", on_delete: :cascade
 end

--- a/spec/feature/admin_contacts_integration_spec.rb
+++ b/spec/feature/admin_contacts_integration_spec.rb
@@ -6,58 +6,57 @@ require 'rails_helper'
 RSpec.describe 'Adding Contacts', type: :feature do
   scenario 'valid add contact - all fields' do
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: 'Greg'
-    fill_in 'Lastname', with: 'abc'
+    fill_in 'First name', with: 'Greg'
+    fill_in 'Last name', with: 'abc'
     fill_in 'Title', with: 'testTitle'
     fill_in 'Bio', with: 'testBio'
     fill_in 'Affiliation', with: 'testAffiliation'
     fill_in 'contact[email]', with: 'gpetri@tamu.edu'
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content('gpetri@tamu.edu')
     expect(page).to have_content('Greg')
     expect(page).to have_content('abc')
-    expect(page).to have_content('gpetri@tamu.edu')
-    expect(page).to have_content('testTitle')
-    visit '/admin/contact?model_name=contact&set=1'
     expect(page).to have_content('testAffiliation')
+    expect(page).to have_content('testTitle')
   end
 
   scenario 'valid add contact - only required fields' do
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: 'Greg2'
-    fill_in 'Lastname', with: 'abc2'
+    fill_in 'First name', with: 'Greg2'
+    fill_in 'Last name', with: 'abc2'
     fill_in 'contact[email]', with: 'gpetri@tamu.edu'
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content('gpetri@tamu.edu')
     expect(page).to have_content('Greg2')
     expect(page).to have_content('abc2')
-    expect(page).to have_content('gpetri@tamu.edu')
   end
 
   scenario 'invalid add contact - no firstname' do
     visit '/admin/contact/new'
-    fill_in 'Lastname', with: 'abc3'
+    fill_in 'Last name', with: 'abc3'
     fill_in 'contact[email]', with: 'test@gmail.com'
     click_on 'Save'
     visit '/admin/contact'
-    expect(page).not_to have_content('abc3')
     expect(page).not_to have_content('test@gmail.com')
+    expect(page).not_to have_content('abc3')
   end
 
   scenario 'invalid add contact - no lastname' do
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: 'abc3'
+    fill_in 'First name', with: 'abc3'
     fill_in 'contact[email]', with: 'test@gmail.com'
     click_on 'Save'
     visit '/admin/contact'
-    expect(page).not_to have_content('abc3')
     expect(page).not_to have_content('test@gmail.com')
+    expect(page).not_to have_content('abc3')
   end
 
   scenario 'invalid add contact - no email' do
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: 'abc3'
-    fill_in 'Lastname', with: 'bca'
+    fill_in 'First name', with: 'abc3'
+    fill_in 'Last name', with: 'bca'
     click_on 'Save'
     visit '/admin/contact'
     expect(page).not_to have_content('abc3')
@@ -74,21 +73,19 @@ RSpec.describe 'Editing Contacts', type: :feature do
     affiliation = 'affiliation baby'
     email = 'test@tamu.edu'
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: firstname
-    fill_in 'Lastname', with: lastname
+    fill_in 'First name', with: firstname
+    fill_in 'Last name', with: lastname
     fill_in 'Title', with: title
     fill_in 'Bio', with: bio
     fill_in 'Affiliation', with: affiliation
     fill_in 'contact[email]', with: email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(title)
-    expect(page).to have_content(email)
-    expect(page).to have_content(bio)
-    visit '/admin/contact?model_name=contact&set=1'
     expect(page).to have_content(affiliation)
+    expect(page).to have_content(title)
     # check the edit page
     visit '/admin/contact'
     tr = page.find('tr', text: firstname)
@@ -115,19 +112,16 @@ RSpec.describe 'Editing Contacts', type: :feature do
     fill_in 'contact[email]', with: new_email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(new_email)
     expect(page).to have_content(new_firstname)
     expect(page).to have_content(new_lastname)
+    expect(page).to have_content(new_affiliation)
     expect(page).to have_content(new_title)
-    expect(page).to have_content(new_bio)
-    expect(page).to have_content(new_email)
+    expect(page).not_to have_content(email)
     expect(page).not_to have_content(firstname)
     expect(page).not_to have_content(lastname)
-    expect(page).not_to have_content(title)
-    expect(page).not_to have_content(bio)
-    expect(page).not_to have_content(email)
-    visit '/admin/contact?model_name=contact&set=1'
-    expect(page).to have_content(new_affiliation)
     expect(page).not_to have_content(affiliation)
+    expect(page).not_to have_content(title)
   end
 
   scenario 'valid edit contact - required fields' do
@@ -135,14 +129,14 @@ RSpec.describe 'Editing Contacts', type: :feature do
     lastname = 'Joe'
     email = 'test@tamu.edu'
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: firstname
-    fill_in 'Lastname', with: lastname
+    fill_in 'First name', with: firstname
+    fill_in 'Last name', with: lastname
     fill_in 'contact[email]', with: email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(email)
     # check the edit page
     tr = page.find('tr', text: firstname)
     contact_id = tr.find('.id_field').text
@@ -162,12 +156,12 @@ RSpec.describe 'Editing Contacts', type: :feature do
     fill_in 'contact[email]', with: new_email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(new_email)
     expect(page).to have_content(new_firstname)
     expect(page).to have_content(new_lastname)
-    expect(page).to have_content(new_email)
+    expect(page).not_to have_content(email)
     expect(page).not_to have_content(firstname)
     expect(page).not_to have_content(lastname)
-    expect(page).not_to have_content(email)
   end
 
   scenario 'invalid edit contact - no firstname' do
@@ -175,8 +169,8 @@ RSpec.describe 'Editing Contacts', type: :feature do
     lastname = 'Joey'
     email = 'testy@tamu.edu'
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: firstname
-    fill_in 'Lastname', with: lastname
+    fill_in 'First name', with: firstname
+    fill_in 'Last name', with: lastname
     fill_in 'contact[email]', with: email
     click_on 'Save'
     visit '/admin/contact'
@@ -198,11 +192,11 @@ RSpec.describe 'Editing Contacts', type: :feature do
     fill_in 'contact[email]', with: new_email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(email)
-    expect(page).not_to have_content(new_lastname)
     expect(page).not_to have_content(new_email)
+    expect(page).not_to have_content(new_lastname)
   end
 
   scenario 'invalid edit contact - no lastname' do
@@ -210,14 +204,14 @@ RSpec.describe 'Editing Contacts', type: :feature do
     lastname = 'Joey'
     email = 'testy@tamu.edu'
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: firstname
-    fill_in 'Lastname', with: lastname
+    fill_in 'First name', with: firstname
+    fill_in 'Last name', with: lastname
     fill_in 'contact[email]', with: email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(email)
     # check the edit page
     tr = page.find('tr', text: firstname)
     contact_id = tr.find('.id_field').text
@@ -233,11 +227,11 @@ RSpec.describe 'Editing Contacts', type: :feature do
     fill_in 'contact[email]', with: new_email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(email)
-    expect(page).not_to have_content(new_firstname)
     expect(page).not_to have_content(new_email)
+    expect(page).not_to have_content(new_firstname)
   end
 
   scenario 'invalid edit contact - no email' do
@@ -245,14 +239,14 @@ RSpec.describe 'Editing Contacts', type: :feature do
     lastname = 'Joey'
     email = 'testy@tamu.edu'
     visit '/admin/contact/new'
-    fill_in 'Firstname', with: firstname
-    fill_in 'Lastname', with: lastname
+    fill_in 'First name', with: firstname
+    fill_in 'Last name', with: lastname
     fill_in 'contact[email]', with: email
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(email)
     # check the edit page
     tr = page.find('tr', text: firstname)
     contact_id = tr.find('.id_field').text
@@ -268,9 +262,9 @@ RSpec.describe 'Editing Contacts', type: :feature do
     fill_in 'contact[lastname]', with: new_lastname
     click_on 'Save'
     visit '/admin/contact'
+    expect(page).to have_content(email)
     expect(page).to have_content(firstname)
     expect(page).to have_content(lastname)
-    expect(page).to have_content(email)
     expect(page).not_to have_content(new_firstname)
     expect(page).not_to have_content(new_lastname)
   end

--- a/spec/feature/admin_events_integration_spec.rb
+++ b/spec/feature/admin_events_integration_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'Editing Events', type: :feature do
   scenario 'valid edit event - all fields' do
     # add an event first
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
-    time_str = Time.now.to_formatted_s
+    time_str = Event.naive_now.to_formatted_s
     # trimmed_time_str = Time.parse(time_str).strftime('%H:%M')
-    advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     # trimmed_advanced_time_str = Time.parse(advanced_time_str).strftime('%H:%M')
     visit '/admin/event/new'
     fill_in 'Name', with: 'Greg'
@@ -21,7 +21,7 @@ RSpec.describe 'Editing Events', type: :feature do
     click_on 'Save'
     visit '/admin/event'
     expect(page).to have_content('Greg')
-    expect(page).to have_content('testDescription')
+    # expect(page).to have_content('testDescription')
     expect(page).to have_content(date_str)
     expect(page).to have_content('codey')
     # expect(page).to have_content(trimmed_time_str)
@@ -39,9 +39,9 @@ RSpec.describe 'Editing Events', type: :feature do
     # expect(page).to have_field('event[endTime]', with: advanced_time_str)
     # edit everything
     new_date_str = Date.tomorrow.to_formatted_s(:long)
-    new_time_str = Time.now.to_formatted_s
+    new_time_str = Event.naive_now.to_formatted_s
     # trimmed_new_time_str = Time.parse(new_time_str).strftime('%H:%M')
-    new_advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    new_advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     # trimmed_new_advanced_time_str = Time.parse(new_advanced_time_str).strftime('%H:%M')
     fill_in 'Name', with: 'Danny'
     fill_in 'event[eventCode]', with: 'cba_code'
@@ -54,7 +54,7 @@ RSpec.describe 'Editing Events', type: :feature do
     visit '/admin/event'
     expect(page).to have_content('Danny')
     expect(page).to have_content('cba_code')
-    expect(page).to have_content('descriptionTest')
+    # expect(page).to have_content('descriptionTest')
     expect(page).to have_content(new_date_str)
     # expect(page).to have_content(trimmed_new_time_str)
     # expect(page).to have_content(trimmed_new_advanced_time_str)
@@ -63,8 +63,8 @@ RSpec.describe 'Editing Events', type: :feature do
   scenario 'valid edit event - some fields' do
     # add an event first
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
-    time_str = Time.now.to_formatted_s
-    advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    time_str = Event.naive_now.to_formatted_s
+    advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     visit '/admin/event/new'
     fill_in 'Name', with: 'Buddy'
     fill_in 'Description', with: 'testDescription'
@@ -76,7 +76,7 @@ RSpec.describe 'Editing Events', type: :feature do
     visit '/admin/event'
     expect(page).to have_content('Buddy')
     expect(page).to have_content('codey')
-    expect(page).to have_content('testDescription')
+    # expect(page).to have_content('testDescription')
     expect(page).to have_content(date_str)
     # test the edit page
     tr = page.find('tr', text: 'Buddy')
@@ -87,13 +87,13 @@ RSpec.describe 'Editing Events', type: :feature do
     expect(page).to have_field('event[date]', with: date_str)
     expect(page).to have_field('event[eventCode]', with: 'codey')
     # edit description
-    fill_in 'Eventcode', with: 'cbad___'
+    fill_in 'Event code', with: 'cbad___'
     click_on 'Save'
     # verify all the info updated
     visit '/admin/event'
     expect(page).to have_content('Buddy')
     expect(page).to have_content('cbad___')
-    expect(page).to have_content('testDescription')
+    # expect(page).to have_content('testDescription')
     expect(page).to have_content(date_str)
   end
 end
@@ -101,9 +101,9 @@ end
 RSpec.describe 'Adding Events', type: :feature do
   scenario 'valid add event - all fields' do
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
-    time_str = Time.now.to_formatted_s
+    time_str = Event.naive_now.to_formatted_s
     # trimmed_time_str = Time.parse(time_str).strftime('%H:%M')
-    advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     # trimmed_advanced_time_str = Time.parse(advanced_time_str).strftime('%H:%M')
     visit '/admin/event/new'
     fill_in 'Name', with: 'Greg'
@@ -116,7 +116,7 @@ RSpec.describe 'Adding Events', type: :feature do
     visit '/admin/event'
     expect(page).to have_content('Greg')
     expect(page).to have_content('codey')
-    expect(page).to have_content('testDescription')
+    # expect(page).to have_content('testDescription')
     expect(page).to have_content(date_str)
     # expect(page).to have_content(trimmed_time_str)
     # expect(page).to have_content(trimmed_advanced_time_str)
@@ -158,8 +158,8 @@ end
 RSpec.describe 'Reviewing Events', type: :feature do
   scenario 'check that event can be viewed to user' do
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
-    time_str = Time.now.to_formatted_s
-    advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    time_str = Event.naive_now.to_formatted_s
+    advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     visit '/admin/event/new'
     fill_in 'Name', with: 'Derek'
     fill_in 'Description', with: 'testDescription'
@@ -170,7 +170,7 @@ RSpec.describe 'Reviewing Events', type: :feature do
     click_on 'Save'
     visit '/admin/event'
     expect(page).to have_content('Derek')
-    expect(page).to have_content('testDescription')
+    # expect(page).to have_content('testDescription')
     expect(page).to have_content(date_str)
     expect(page).to have_content('codey')
     visit '/'
@@ -183,8 +183,8 @@ end
 RSpec.describe 'Deleting Events', type: :feature do
   scenario 'remove an event successfully' do
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
-    time_str = Time.now.to_formatted_s
-    advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    time_str = Event.naive_now.to_formatted_s
+    advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     visit '/admin/event/new'
     fill_in 'Name', with: 'Betty'
     fill_in 'Description', with: 'bettyDescription'
@@ -195,7 +195,7 @@ RSpec.describe 'Deleting Events', type: :feature do
     click_on 'Save'
     visit '/admin/event'
     expect(page).to have_content('Betty')
-    expect(page).to have_content('bettyDescription')
+    # expect(page).to have_content('bettyDescription')
     expect(page).to have_content(date_str)
     expect(page).to have_content('codey')
     tr = page.find('tr', text: 'Betty')
@@ -204,14 +204,14 @@ RSpec.describe 'Deleting Events', type: :feature do
     click_on "Yes, I'm sure"
     visit '/admin/event'
     expect(page).not_to have_content('Betty')
-    expect(page).not_to have_content('bettyDescription')
+    # expect(page).not_to have_content('bettyDescription')
     expect(page).not_to have_content('codey')
   end
 
   scenario 'cancel removing an event successfully' do
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
-    time_str = Time.now.to_formatted_s
-    advanced_time_str = Time.now.advance(minutes: 1).to_formatted_s
+    time_str = Event.naive_now.to_formatted_s
+    advanced_time_str = Event.naive_now.advance(minutes: 1).to_formatted_s
     visit '/admin/event/new'
     fill_in 'Name', with: 'Bobby'
     fill_in 'Description', with: 'bobbyDescription'
@@ -222,7 +222,7 @@ RSpec.describe 'Deleting Events', type: :feature do
     click_on 'Save'
     visit '/admin/event'
     expect(page).to have_content('Bobby')
-    expect(page).to have_content('bobbyDescription')
+    # expect(page).to have_content('bobbyDescription')
     expect(page).to have_content(date_str)
     expect(page).to have_content('codey')
     tr = page.find('tr', text: 'Bobby')
@@ -231,7 +231,7 @@ RSpec.describe 'Deleting Events', type: :feature do
     click_on 'Cancel'
     visit '/admin/event'
     expect(page).to have_content('Bobby')
-    expect(page).to have_content('bobbyDescription')
+    # expect(page).to have_content('bobbyDescription')
     expect(page).to have_content(date_str)
     expect(page).to have_content('codey')
   end

--- a/spec/feature/events_users_integration_spec.rb
+++ b/spec/feature/events_users_integration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Checking In', type: :feature do
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
     visit '/admin/event/new'
     fill_in 'Name', with: 'Greg'
-    fill_in 'Eventcode', with: 'abc'
+    fill_in 'Event code', with: 'abc'
     fill_in 'Description', with: 'testDescription'
     fill_in 'event[date]', with: date_str
     fill_in 'event[eventCode]', with: 'codey'
@@ -31,7 +31,7 @@ RSpec.describe 'Checking In', type: :feature do
     date_str = Event.naive_now.to_date.to_formatted_s(:long)
     visit '/admin/event/new'
     fill_in 'Name', with: 'Greg'
-    fill_in 'Eventcode', with: 'abc'
+    fill_in 'Event code', with: 'abc'
     fill_in 'Description', with: 'testDescription'
     fill_in 'event[date]', with: date_str
     fill_in 'event[eventCode]', with: 'codey'

--- a/spec/unit/events_unit_spec.rb
+++ b/spec/unit/events_unit_spec.rb
@@ -20,4 +20,58 @@ RSpec.describe Event, type: :model do
     subject.endTime = nil
     expect(subject).not_to be_valid
   end
+
+  it 'round-trips between naive and real timezones' do
+    # Ensure that Event::corrected_time and Event::naive_time are inverse operations
+    now = Time.now.in_time_zone('Central Time (US & Canada)')
+    round_trip_converted_now = Event.corrected_time Event.naive_time now
+    expect(round_trip_converted_now).to eq(now)
+  end
+
+  it 'categorizes ongoing events properly' do
+    now = Event.naive_now
+    today = now.to_date
+    event = described_class.create(name: 'Ongoing Event', eventCode: 'X', date: today)
+    expect(Event.ongoing).to include(event)
+    event.startTime = now - 10.minutes
+    expect(Event.ongoing).to include(event)
+    event.endTime = now + 10.minutes
+    expect(Event.ongoing).to include(event)
+
+    expect(Event.upcoming).not_to include(event)
+    expect(Event.past).not_to include(event)
+  end
+
+  it 'categorizes upcoming events properly' do
+    now = Event.naive_now
+    today = now.to_date
+    event = described_class.create(name: 'Upcoming Event', eventCode: 'X', date: today, startTime: now + 10.minutes)
+    expect(Event.upcoming).to include(event)
+    event.endTime = now + 15.minutes
+    expect(Event.upcoming).to include(event)
+
+    expect(Event.ongoing).not_to include(event)
+    expect(Event.past).not_to include(event)
+
+    event.date = today + 1
+    event.startTime = now + 1.day - 15.minutes
+    event.startTime = now + 1.day - 10.minutes
+    expect(Event.upcoming).to include(event)
+  end
+
+  it 'categorizes past events properly' do
+    now = Event.naive_now
+    today = now.to_date
+    event = described_class.create(name: 'Past Event', eventCode: 'X', date: today,
+                                   startTime: now - 15.minutes, endTime: now - 10.minutes)
+    expect(Event.past).to include(event)
+
+    expect(Event.ongoing).not_to include(event)
+    expect(Event.upcoming).not_to include(event)
+
+    event.date = today - 1
+    event.startTime = now - 1.day - 10.minutes
+    event.endTime = now - 1.day + 10.minutes
+    expect(Event.past).to include(event)
+  end
 end


### PR DESCRIPTION
This pull request adds in all of the `has_many` and `belongs_to` relations in the existing database tables, as well as adding in true foreign key constraints in the RDBMS where appropriate, ensuring referential integrity. Furthermore, delete rules will now clear out invalid check-ins when orphaned by their associated event or user being deleted.

The other major feature of this pull request is extensive customization of our RailsAdmin page.
Adding in the appropriate relationships in ActiveRecord has the effect of creating clickable links and rich editor fields between all relevant models in our table, for which intuitive names were then added.
The columns shown in the admin's model views were significantly pruned to reduce information overload and increase usability, and read-only *virtual fields* were added to the `Events` and `Users` tabs summarizing each object's total number of attendees and total number of attended meetings, respectively, accessible in exports.

The `Users` view now appears as such, now showcasing the relevant content, with points baked in as the read-only "Count attended" field:
![The Users admin view index](https://user-images.githubusercontent.com/90056552/140478246-ecf09071-701e-4f8d-a5bf-cfb166991942.png)

The show page for a user has their full info:
![The show view for a user](https://files.slack.com/files-pri/T02D4L5Q98D-F02L75CB3NH/image.png?pub_secret=5c9c966f2e)

Editing lets you very easily modify their attended events and automatically creates the appropriate links:
![The edit view for a user](https://files.slack.com/files-pri/T02D4L5Q98D-F02LA55V3KM/image.png?pub_secret=9b7deeed3c)

The `Events` page is similar with a calculated "Attendance" count column:
![The Events index](https://files.slack.com/files-pri/T02D4L5Q98D-F02L3D4BYH4/image.png?pub_secret=f16d5e32fa)

And you can view exactly who attended in the show page:
![The show view for an event](https://files.slack.com/files-pri/T02D4L5Q98D-F02LA5AS2EP/image.png?pub_secret=62b57b1b69)

The view for `EventsUsers` was vastly simplified for usability since it's mostly technical information; the entire view in the app (though not in the database) was renamed to "Check-ins":
![The Check-ins index](https://files.slack.com/files-pri/T02D4L5Q98D-F02LCBQ8W5A/image.png?pub_secret=8c49e145b0)

Also note that any of the virtual columns can be exported just like other fields in the export tab:
![An event export view](https://files.slack.com/files-pri/T02D4L5Q98D-F02LZRB1G9E/image.png?pub_secret=21d522f14e)

I updated all of the test specs to match the new layout of the pages, and as such, `rspec` completes with no errors, still maintaining >90% coverage.
This covers a broad spectrum of user stories and is a massive usability update. In particular, AP-17, _Manually Enter/Override Points_ is completed with this change according to its acceptance criteria, as you can view member points, change them, and have their display update automatically in the new `Users` view.

The typical prerequisite definition of done elements are also satisfied:
- [x] RuboCop passes
- [x] Test coverage verified by SimpleCov
- [x] Deploys to Heroku correctly
- [ ] Pull request made and code reviewed by peer(s) **← we are here**
- [ ] Merged to main